### PR TITLE
user-flow系シナリオで待機追加

### DIFF
--- a/packages/core/src/scenarios/2024.ts
+++ b/packages/core/src/scenarios/2024.ts
@@ -235,6 +235,7 @@ export const generateScenarios = (entrypoint: string): MeasureScenario[] => [
           await page.click('button[type="submit"]');
           await waitElementWithText(page, 'button', 'ログアウト');
           await page.goto(`${normalizedEntrypoint}/admin/books`);
+          await page.waitForNetworkIdle();
         }
       } catch (err) {
         throw new Error(`ログインに失敗しました`);
@@ -318,6 +319,7 @@ export const generateScenarios = (entrypoint: string): MeasureScenario[] => [
           await page.click('button[type="submit"]');
           await waitElementWithText(page, 'button', 'ログアウト');
           await page.goto(`${normalizedEntrypoint}/admin/books/${bookId}/episodes/new`);
+          await page.waitForNetworkIdle();
         }
       } catch (err) {
         throw new Error(`ログインに失敗しました`);

--- a/packages/core/src/scoring.ts
+++ b/packages/core/src/scoring.ts
@@ -196,6 +196,7 @@ export const measureUserFlow = async (
 ) => {
   const page = await getPage(port);
   await page.goto(url);
+  await page.waitForNetworkIdle();
 
   const flow = await startFlow(page, {
     config: lhConfig,


### PR DESCRIPTION
user-flow系シナリオでレンダリング完了前にシナリオが走った結果、使用に支障がない場合でもエラーとなる事象が発生していました。
これを解決するために、ページ遷移後に`waitForNetworkIdle`によりネットワーク利用が落ち着くまで待機するように修正しました。
確認よろしくお願いします。